### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,5 @@
 ^_pkgdown\.yml$
 ^README\.Rmd$
 ^CODE_OF_CONDUCT\.md$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/tests/testthat/test-not-in.R
+++ b/tests/testthat/test-not-in.R
@@ -21,16 +21,16 @@ test_that("output has no NA values", {
 
 test_that("input and search a seqence of numbers", {
   output <- seq(1, 3, 1) %nin% seq(1, 3, 1)
-  expect_equal(output,c(FALSE, FALSE, FALSE))
+  expect_equal(output, c(FALSE, FALSE, FALSE))
 })
 
 test_that("output is a logical vector", {
-  output <-  c(1, 2, 3) %nin% c(4, 5, 6)
+  output <- c(1, 2, 3) %nin% c(4, 5, 6)
   expect_type(output, "logical")
 })
 
 test_that("inverse is calculated correctly", {
-  output <-  !(c(1) %nin% c(4, 5, 6))
+  output <- !(c(1) %nin% c(4, 5, 6))
   expect_equal(output, FALSE)
 })
 
@@ -73,11 +73,11 @@ test_that("character numbers are matched to ints", {
 })
 
 test_that("character number matched to doubles", {
-  output <- as.character(1) %nin%  c(1, 2, 3)
+  output <- as.character(1) %nin% c(1, 2, 3)
   expect_equal(output, FALSE)
 })
 
 test_that("character number matched to ints", {
-  output <- as.character(1) %nin%  c(1L, 2L, 3L)
+  output <- as.character(1) %nin% c(1L, 2L, 3L)
   expect_equal(output, FALSE)
 })


### PR DESCRIPTION
Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)